### PR TITLE
8385332: aarch32 started to crash after 8261235

### DIFF
--- a/hotspot/src/cpu/aarch32/vm/bytes_aarch32.hpp
+++ b/hotspot/src/cpu/aarch32/vm/bytes_aarch32.hpp
@@ -38,43 +38,133 @@ class Bytes: AllStatic {
   // AArch32 is little-endian, Java is big-endian; returns true
   static inline bool is_Java_byte_ordering_different(){ return true; }
 
+  static inline u2 get_Java_u2(address p) {
+    return (u2(p[0]) << 8) | u2(p[1]);
+  }
 
-  // Efficient reading and writing of unaligned unsigned data in platform-specific byte ordering.
-  // Since ARMv6 unaligned short and word accesses are handled by hardware.
-  // However, unaligned double-word access causes kernel trap and software processing,
-  // so we turn it to fast unalinged word access.
-  static inline u2   get_native_u2(address p)         { return *(u2*)p; }
-  static inline u4   get_native_u4(address p)         { return *(u4*)p; }
-  static inline u8   get_native_u8(address p)         {
-    if (!(uintptr_t(p) & 3)) {
-      return *(u8*)p;
+  static inline u4 get_Java_u4(address p) {
+    return u4(p[0]) << 24 |
+           u4(p[1]) << 16 |
+           u4(p[2]) <<  8 |
+           u4(p[3]);
+  }
+
+  static inline u8 get_Java_u8(address p) {
+    return u8(p[0]) << 56 |
+           u8(p[1]) << 48 |
+           u8(p[2]) << 40 |
+           u8(p[3]) << 32 |
+           u8(p[4]) << 24 |
+           u8(p[5]) << 16 |
+           u8(p[6]) <<  8 |
+           u8(p[7]);
+  }
+
+  static inline void put_Java_u2(address p, u2 x) {
+    p[0] = x >> 8;
+    p[1] = x;
+  }
+
+  static inline void put_Java_u4(address p, u4 x) {
+    ((u1*)p)[0] = x >> 24;
+    ((u1*)p)[1] = x >> 16;
+    ((u1*)p)[2] = x >>  8;
+    ((u1*)p)[3] = x;
+  }
+
+  static inline void put_Java_u8(address p, u8 x) {
+    ((u1*)p)[0] = x >> 56;
+    ((u1*)p)[1] = x >> 48;
+    ((u1*)p)[2] = x >> 40;
+    ((u1*)p)[3] = x >> 32;
+    ((u1*)p)[4] = x >> 24;
+    ((u1*)p)[5] = x >> 16;
+    ((u1*)p)[6] = x >>  8;
+    ((u1*)p)[7] = x;
+  }
+
+  static inline u2 get_native_u2(address p) {
+    return (intptr_t(p) & 1) == 0 ? *(u2*)p : u2(p[0]) | (u2(p[1]) << 8);
+  }
+
+  static inline u4 get_native_u4(address p) {
+    switch (intptr_t(p) & 3) {
+      case 0:  return *(u4*)p;
+      case 2:  return u4(((u2*)p)[0]) |
+                      u4(((u2*)p)[1]) << 16;
+      default: return u4(p[0])       |
+                      u4(p[1]) <<  8 |
+                      u4(p[2]) << 16 |
+                      u4(p[3]) << 24;
+    }
+  }
+
+  static inline u8 get_native_u8(address p) {
+    switch (intptr_t(p) & 7) {
+      case 0:  return *(u8*)p;
+      case 4:  return u8(((u4*)p)[0]) |
+                      u8(((u4*)p)[1]) << 32;
+      case 2:  return u8(((u2*)p)[0])       |
+                      u8(((u2*)p)[1]) << 16 |
+                      u8(((u2*)p)[2]) << 32 |
+                      u8(((u2*)p)[3]) << 48;
+      default: return u8(p[0])       |
+                      u8(p[1]) <<  8 |
+                      u8(p[2]) << 16 |
+                      u8(p[3]) << 24 |
+                      u8(p[4]) << 32 |
+                      u8(p[5]) << 40 |
+                      u8(p[6]) << 48 |
+                      u8(p[7]) << 56;
     }
     u4 *const a = (u4*) p;
     return (u8(a[1]) << 32) | a[0];
   }
 
-  static inline void put_native_u2(address p, u2 x)   { *(u2*)p = x; }
-  static inline void put_native_u4(address p, u4 x)   { *(u4*)p = x; }
-  static inline void put_native_u8(address p, u8 x)   { *(u8*)p = x; }
-
-
-  // Efficient reading and writing of unaligned unsigned data in Java
-  // byte ordering (i.e. big-endian ordering). Byte-order reversal is
-  // needed since AArch32 use little-endian format.
-  static inline u2   get_Java_u2(address p)           { return swap_u2(get_native_u2(p)); }
-  static inline u4   get_Java_u4(address p)           { return swap_u4(get_native_u4(p)); }
-  static inline u8   get_Java_u8(address p)           { return swap_u8(get_native_u8(p)); }
-
-  static inline void put_Java_u2(address p, u2 x)     { put_native_u2(p, swap_u2(x)); }
-  static inline void put_Java_u4(address p, u4 x)     { put_native_u4(p, swap_u4(x)); }
-  static inline void put_Java_u8(address p, u8 x)     {
-    const u8 nx = swap_u8(x);
-    if (!(uintptr_t(p) & 3)) {
-      *(u8*)p = nx;
+  static inline void put_native_u2(address p, u2 x) {
+    if ((intptr_t(p) & 1) == 0) {
+      *(u2*)p = x;
     } else {
-      u4 *const a = (u4*) p;
-      a[0] = nx;
-      a[1] = nx >> 32;
+      p[0] = x;
+      p[1] = x >> 8;
+    }
+  }
+
+  static inline void put_native_u4(address p, u4 x) {
+    switch (intptr_t(p) & 3) {
+      case 0:  *(u4*)p = x;
+               break;
+      case 2:  ((u2*)p)[0] = x;
+               ((u2*)p)[1] = x >> 16;
+               break;
+      default: ((u1*)p)[0] = x;
+               ((u1*)p)[1] = x >>  8;
+               ((u1*)p)[2] = x >> 16;
+               ((u1*)p)[3] = x >> 24;
+               break;
+    }
+  }
+
+  static inline void put_native_u8(address p, u8 x) {
+    switch (intptr_t(p) & 7) {
+      case 0:  *(u8*)p = x;
+               break;
+      case 4:  ((u4*)p)[0] = x;
+               ((u4*)p)[1] = x >> 32;
+               break;
+      case 2:  ((u2*)p)[0] = x;
+               ((u2*)p)[1] = x >> 16;
+               ((u2*)p)[2] = x >> 32;
+               ((u2*)p)[3] = x >> 48;
+               break;
+      default: ((u1*)p)[0] = x;
+               ((u1*)p)[1] = x >>  8;
+               ((u1*)p)[2] = x >> 16;
+               ((u1*)p)[3] = x >> 24;
+               ((u1*)p)[4] = x >> 32;
+               ((u1*)p)[5] = x >> 40;
+               ((u1*)p)[6] = x >> 48;
+               ((u1*)p)[7] = x >> 56;
     }
   }
 

--- a/hotspot/src/cpu/aarch32/vm/bytes_aarch32.hpp
+++ b/hotspot/src/cpu/aarch32/vm/bytes_aarch32.hpp
@@ -117,8 +117,6 @@ class Bytes: AllStatic {
                       u8(p[6]) << 48 |
                       u8(p[7]) << 56;
     }
-    u4 *const a = (u4*) p;
-    return (u8(a[1]) << 32) | a[0];
   }
 
   static inline void put_native_u2(address p, u2 x) {

--- a/hotspot/src/cpu/aarch32/vm/bytes_aarch32.hpp
+++ b/hotspot/src/cpu/aarch32/vm/bytes_aarch32.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * Copyright (c) 2015, Linaro Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.


### PR DESCRIPTION
Hi! 

This fixes many long-standing bugs that affected the aarch32 port. However, I only decided to investigate the issue in detail after the latest sync with 8u502-b02, which introduced a new test that started failing.

The patch actually copies [Bytes](https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/arm/bytes_arm.hpp) implementation from mainline OpenJDK repository. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8385332](https://bugs.openjdk.org/browse/JDK-8385332): aarch32 started to crash after 8261235 (**Bug** - P3)


### Reviewers
 * [Boris Ulasevich](https://openjdk.org/census#bulasevich) (@bulasevich - no project role)
 * [Anton Kozlov](https://openjdk.org/census#akozlov) (@AntonKozlov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/aarch32-port-jdk8u.git pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.org/aarch32-port-jdk8u.git pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/aarch32-port-jdk8u/pull/2.diff">https://git.openjdk.org/aarch32-port-jdk8u/pull/2.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/aarch32-port-jdk8u/pull/2#issuecomment-4534668650)
</details>
